### PR TITLE
Download CSV file directly without temporarily saving in storage

### DIFF
--- a/Exportit/ExportitController.php
+++ b/Exportit/ExportitController.php
@@ -20,13 +20,13 @@ class ExportitController extends Controller
      *
      * @return mixed
      */
-    public function index() {
-
-
+    public function index()
+    {
         return $this->view('index');
     }
 
-    public function exportdata() {
+    public function exportdata()
+    {
         $handle = $_POST['selectedcollection'];
 
         $this->writer = Writer::createFromFileObject(new SplTempFileObject);
@@ -41,14 +41,15 @@ class ExportitController extends Controller
         $data = [
             'csv' => $this->writer
         ];
+
         return $this->view('exportdata');
-
-
     }
 
-    public function download() {
+    public function download()
+    {
         $document = File::disk('storage');
         $file = $document->get('exportit.csv');
+
         return response($file)->header('Content-Type', 'text/csv')->header('Content-Disposition', 'attachment; filename="exportit.csv"');
     }
 
@@ -63,7 +64,7 @@ class ExportitController extends Controller
         $header_data = array_keys($fieldset_content);
 
         // Adding title field, since it is not defined in fieldset
-        array_unshift($header_data, 'title' );
+        array_unshift($header_data, 'title');
 
         $this->csv_header = $header_data;
 
@@ -78,30 +79,28 @@ class ExportitController extends Controller
         $collectiondata = Entry::whereCollection($handle);
 
         $data = collect($collectiondata)->map(function ($entry) use ($header_data) {
-
-            $ret = array();
+            $ret = [];
             $entry = $entry->toArray();
 
             foreach ($header_data as $key => $value) {
-                if(array_key_exists($value, $entry)) {
+                if (array_key_exists($value, $entry)) {
                     // convert entry array to pipe delimited string
                     $entry_value = '';
-                    if(is_array($entry[$value])) {
+                    if (is_array($entry[$value])) {
                         $entry_value = implode('|', $entry[$value]);
                     } else {
                         $entry_value = $entry[$value];
                     }
 
                     $ret[] = $entry_value;
-                }
-                else {
+                } else {
                     $ret[] = '';
                 }
             }
+
             return $ret;
         })->toArray();
 
         $this->writer->insertAll($data);
-
     }
 }

--- a/Exportit/meta.yaml
+++ b/Exportit/meta.yaml
@@ -1,5 +1,5 @@
 name: exportit
-version: "1.0"
+version: 1.1
 description: Exports Data from a Collection to CSV
 developer: Stefan Göllner
 developer_url: https://www.goellner.io/

--- a/Exportit/resources/views/exportdata.blade.php
+++ b/Exportit/resources/views/exportdata.blade.php
@@ -1,7 +1,0 @@
-@extends('layout')
-
-@section('content')
-    <div class="card">
-        <a href="{{ route('exportit.download') }}"  type="button" class="btn btn-default">Export</a>
-    </div>
-@endsection

--- a/Exportit/resources/views/index.blade.php
+++ b/Exportit/resources/views/index.blade.php
@@ -1,7 +1,7 @@
 @extends('layout')
 
 @section('content')
-    <form action="{{ route('exportit.exportdata') }}" method="post">
+    <form method="POST">
         {{ csrf_field() }}
 
         <div class="card flush flat-bottom">

--- a/Exportit/routes.yaml
+++ b/Exportit/routes.yaml
@@ -2,9 +2,6 @@ routes:
   /:
     as: addons.exportit
     uses: index
-  post@exportdata:
+  post@/:
     uses: exportdata
     as: exportit.exportdata
-  download:
-    uses: download
-    as: exportit.download


### PR DESCRIPTION
This PR modifies the `exportdata` method to force download of the generated CSV directly, without having to temporarily save it to storage. This also allows the route file to be simplified slightly, and remove the need for the extra `exportdata ` view.

Additionally, the filename is automatically generated using the collection's handle + the current timestamp, ensuring a unique filename and potentially also better auditability.