### PR TITLE
flatten multi-dimensional arrays if dealing with an array

### DIFF
--- a/Exportit/ExportitController.php
+++ b/Exportit/ExportitController.php
@@ -75,7 +75,7 @@ class ExportitController extends Controller
                     // convert entry array to pipe delimited string
                     $entry_value = '';
                     if (is_array($entry[$value])) {
-                        $entry_value = implode('|', $entry[$value]);
+                        $entry_value = implode('|', array_flatten($entry[$value]));
                     } else {
                         $entry_value = $entry[$value];
                     }


### PR DESCRIPTION
Just in case we have a bard or replicator that is a multi-dimensional array it will prevent an error on export!

I just needed to implement it, so figured I'd send it along! know it has been awhile! 