### PR TITLE
Add slug and date to the export

### DIFF
--- a/Exportit/ExportitController.php
+++ b/Exportit/ExportitController.php
@@ -51,8 +51,8 @@ class ExportitController extends Controller
         $fieldset_content = $fieldset->fields();
         $header_data = array_keys($fieldset_content);
 
-        // Adding title field, since it is not defined in fieldset
-        array_unshift($header_data, 'title');
+        // Explicitly adding some fields that may not be defined in fieldset
+        array_unshift($header_data, 'title', 'slug', 'date');
 
         $this->csv_header = $header_data;
 


### PR DESCRIPTION
Not sure if you're expecting/taking PRs for this. I just needed to use it to export some content and found this simple trick to get the `slug` and `date` from the collections in question, which we also needed. Thought someone else may find this useful.